### PR TITLE
Add ARM64 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN cd amneziawg-tools/src && \
     make
 
 FROM alpine:${ALPINE_VERSION}
-RUN apk update && apk add --no-cache bash openrc iptables iptables-legacy iproute2
+RUN apk update && apk add --no-cache bash openrc iptables iptables-legacy iproute2 openresolv
 COPY amnezia-wg/amneziawg-go /usr/bin/amneziawg-go
 COPY --from=builder /go/amneziawg-tools/src/wg /usr/bin/awg
 COPY --from=builder /go/amneziawg-tools/src/wg-quick/linux.bash /usr/bin/awg-quick

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ awg-arm7:
 	cd amnezia-wg; make clean; GOOS=linux GOARCH=arm GOARM=7 make; cd ..
 awg-mips:
 	cd amnezia-wg; make clean; GOOS=linux GOARCH=mipsle GOMIPS=softfloat make; cd ..
+awg-arm64:
+        cd amnezia-wg; make clean; GOOS=linux GOARCH=arm64 make; cd ..
 
 build-arm7: awg-arm7
 	DOCKER_BUILDKIT=1  docker buildx build --no-cache --platform linux/arm/v7 --output=type=docker --tag docker-awg:latest .
@@ -9,3 +11,8 @@ build-arm7: awg-arm7
 export-arm7: build-arm7
 	docker save docker-awg:latest > docker-awg-arm7.tar
 
+build-arm64:
+        DOCKER_BUILDKIT=1  docker buildx build --no-cache --platform linux/arm64 --output=type=docker --tag docker-awg:latest .
+
+export-arm64: build-arm64
+        docker save docker-awg:latest > docker-awg-arm64.tar


### PR DESCRIPTION
Add ability to compile for ARM64 platforms.
Use `build-arm64` and `export-arm64` commands for that.

Also added `openresolv` package to image.